### PR TITLE
fix: filter exits requests by validators status

### DIFF
--- a/dappnode/hooks/use-get-exit-requests.ts
+++ b/dappnode/hooks/use-get-exit-requests.ts
@@ -34,8 +34,18 @@ const useGetExitRequests = () => {
         throw new Error(`HTTP error! Status: ${response.status}`);
       }
 
-      const data = await response.json();
-      setExitRequests(data);
+      const data: ExitRequests = await response.json();
+
+      // Statuses to include if have not started/ended the exit process
+      const includedStatuses = ['active_ongoing', 'active_slashed'];
+
+      const filteredData = Object.fromEntries(
+        Object.entries(data).filter(([, exitRequest]) =>
+          includedStatuses.includes(exitRequest.status),
+        ),
+      );
+
+      setExitRequests(filteredData);
     } catch (e) {
       console.error(
         `Error GETting validators exit requests from indexer API: ${e}`,


### PR DESCRIPTION
## Description

Before displaying the `Exit Validator` warning on the `/dashboard` page, the status of the returned validators is checked. If the validator has already exited or initiated the exit process, the warning will not be shown.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist

- [ ] Requires other services change
- [ ] Affects to other services
- [ ] Requires dependency update
- [ ] Automated tests
- [ ] Looks good on large screens
- [ ] Looks good on mobile
