### PR TITLE
fix: spinner on getting performance

### DIFF
--- a/dappnode/hooks/use-get-performance-by-range.ts
+++ b/dappnode/hooks/use-get-performance-by-range.ts
@@ -4,8 +4,7 @@ import { Range, ValidatorStats } from '../performance/types';
 import { useAccount } from 'shared/hooks';
 
 export const useGetPerformanceByRange = (range: Range) => {
-  const [isLoading, setIsLoading] = useState(true);
-  const { operatorData } = useGetOperatorPerformance();
+  const { operatorData, isLoading } = useGetOperatorPerformance();
   const [operatorDataByRange, setOperatorDataByRange] = useState<
     Record<string, any>
   >({});
@@ -27,7 +26,6 @@ export const useGetPerformanceByRange = (range: Range) => {
   useEffect(() => {
     if (!operatorData) return;
 
-    setIsLoading(true);
     const sortedKeys = Object.keys(operatorData).sort((a, b) => {
       const [startA] = a.split('-').map(Number);
       const [startB] = b.split('-').map(Number);
@@ -167,10 +165,6 @@ export const useGetPerformanceByRange = (range: Range) => {
     const result = getValidatorStats(statsPerValidator);
     setValidatorsStats(result);
   }, [operatorDataByRange]);
-
-  useEffect(() => {
-    setIsLoading(false);
-  }, [validatorsStats]);
 
   return {
     isLoading,


### PR DESCRIPTION
## Description

Wait for backend response to display the table and chart in `/performance`

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist

- [ ] Requires other services change
- [ ] Affects to other services
- [ ] Requires dependency update
- [ ] Automated tests
- [ ] Looks good on large screens
- [ ] Looks good on mobile
