### PR TITLE
fix: Rely on wallet provider

### DIFF
--- a/dappnode/hooks/use-ec-sanity-check.ts
+++ b/dappnode/hooks/use-ec-sanity-check.ts
@@ -1,6 +1,7 @@
 import { CHAINS } from '@lido-sdk/constants';
 import getConfig from 'next/config';
 import { useEffect, useMemo, useState } from 'react';
+import { useAccount } from 'shared/hooks';
 
 export const useECSanityCheck = () => {
   const [isInstalled, setIsInstalled] = useState<boolean>(false);
@@ -9,7 +10,7 @@ export const useECSanityCheck = () => {
   const [isLoading, setIsLoading] = useState<boolean>(true);
   const { publicRuntimeConfig } = getConfig();
 
-  const chainId = publicRuntimeConfig.defaultChain;
+  const { chainId } = useAccount();
 
   const contractTx = useMemo(
     () => ({


### PR DESCRIPTION
## Description

Instead of retrieving the `chainId` from the envs, it is now determined through the wallet provider to check the EC status

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist

- [ ] Requires other services change
- [ ] Affects to other services
- [ ] Requires dependency update
- [ ] Automated tests
- [ ] Looks good on large screens
- [ ] Looks good on mobile
