### PR TITLE
fix: EC gates on loading

### DIFF
--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,4 +1,7 @@
 import { SecretConfigType } from 'config';
+import { ECNoLogsPage } from 'dappnode/fallbacks/ec-no-logs-page';
+import { ECNotInstalledPage } from 'dappnode/fallbacks/ec-not-installed-page';
+import { ECSyncingPage } from 'dappnode/fallbacks/ec-syncing-page';
 import { DashboardPage } from 'features/dashboard';
 import { StarterPackPage } from 'features/starter-pack';
 import { WelcomePage } from 'features/welcome';
@@ -14,13 +17,20 @@ const Page: FC<PageProps> = ({ maintenance }) => {
   if (maintenance) return <MaintenancePage />;
 
   return (
-    <GateLoaded>
-      <Gate rule="IS_CONNECTED_WALLET" fallback={<WelcomePage />}>
-        <Gate rule="IS_NODE_OPERATOR" fallback={<StarterPackPage />}>
-          <DashboardPage />
+    // DAPPNODE GATES: IS_EXECUTION_INSTALLED, IS_EXECUTION_SYNCED, EXECUTION_HAS_LOGS
+    <Gate rule="IS_EXECUTION_INSTALLED" fallback={<ECNotInstalledPage />}>
+      <Gate rule="IS_EXECUTION_SYNCED" fallback={<ECSyncingPage />}>
+        <Gate rule="EXECUTION_HAS_LOGS" fallback={<ECNoLogsPage />}>
+          <GateLoaded>
+            <Gate rule="IS_CONNECTED_WALLET" fallback={<WelcomePage />}>
+              <Gate rule="IS_NODE_OPERATOR" fallback={<StarterPackPage />}>
+                <DashboardPage />
+              </Gate>
+            </Gate>
+          </GateLoaded>
         </Gate>
       </Gate>
-    </GateLoaded>
+    </Gate>
   );
 };
 

--- a/shared/hooks/use-show-rule.ts
+++ b/shared/hooks/use-show-rule.ts
@@ -1,3 +1,4 @@
+import { useECSanityCheck } from 'dappnode/hooks/use-ec-sanity-check';
 import { useNodeOperatorContext } from 'providers/node-operator-provider';
 import { useCallback } from 'react';
 import {
@@ -17,7 +18,13 @@ export type ShowRule =
   | 'HAS_REWARDS_ROLE'
   | 'HAS_LOCKED_BOND'
   | 'CAN_CREATE'
-  | 'EL_STEALING_REPORTER';
+  | 'EL_STEALING_REPORTER'
+
+  // DAPPNODE
+  | 'IS_EXECUTION_LOADING'
+  | 'IS_EXECUTION_INSTALLED'
+  | 'IS_EXECUTION_SYNCED'
+  | 'EXECUTION_HAS_LOGS';
 
 export const useShowRule = () => {
   const { active: isConnectedWallet } = useAccount();
@@ -26,6 +33,9 @@ export const useShowRule = () => {
   const { data: isReportingRole } = useIsReportStealingRole();
   const { data: lockedBond } = useNodeOperatorLockAmount(nodeOperator?.id);
   const canCreateNO = useCanCreateNodeOperator();
+
+  // DAPPNODE
+  const { isInstalled, isSynced, hasLogs } = useECSanityCheck();
 
   return useCallback(
     (condition: ShowRule): boolean => {
@@ -48,6 +58,14 @@ export const useShowRule = () => {
           return !!lockedBond?.gt(0);
         case 'EL_STEALING_REPORTER':
           return !!isReportingRole;
+
+        // DAPPNODE
+        case 'IS_EXECUTION_INSTALLED':
+          return isInstalled;
+        case 'IS_EXECUTION_SYNCED':
+          return isSynced;
+        case 'EXECUTION_HAS_LOGS':
+          return hasLogs;
         default:
           return false;
       }
@@ -59,6 +77,9 @@ export const useShowRule = () => {
       invites?.length,
       lockedBond,
       isReportingRole,
+      isInstalled,
+      isSynced,
+      hasLogs,
     ],
   );
 };

--- a/shared/navigate/gates/gate-loaded.tsx
+++ b/shared/navigate/gates/gate-loaded.tsx
@@ -3,11 +3,6 @@ import { FC, PropsWithChildren, ReactNode } from 'react';
 import { useAccount, useCsmPaused, useCsmPublicRelease } from 'shared/hooks';
 import { useCsmEarlyAdoption } from 'shared/hooks/useCsmEarlyAdoption';
 import { SplashPage } from '../splash';
-// DAPPNODE
-import { useECSanityCheck } from 'dappnode/hooks/use-ec-sanity-check';
-import { ECNotInstalledPage } from 'dappnode/fallbacks/ec-not-installed-page';
-import { ECNoLogsPage } from 'dappnode/fallbacks/ec-no-logs-page';
-import { ECSyncingPage } from 'dappnode/fallbacks/ec-syncing-page';
 import { ECScanningPage } from 'dappnode/fallbacks/ec-scanning-events';
 
 type Props = {
@@ -16,7 +11,6 @@ type Props = {
 };
 
 export const GateLoaded: FC<PropsWithChildren<Props>> = ({
-  fallback,
   additional,
   children,
 }) => {
@@ -25,43 +19,16 @@ export const GateLoaded: FC<PropsWithChildren<Props>> = ({
   const { isConnecting } = useAccount();
   const { isListLoading, active } = useNodeOperatorContext();
   const { initialLoading: isEaLoading } = useCsmEarlyAdoption();
+
   // DAPPNODE
-  const {
-    isInstalled,
-    isLoading: isECLoading,
-    isSynced,
-    hasLogs,
-  } = useECSanityCheck();
+  const fallback = isListLoading ? <ECScanningPage /> : <SplashPage />;
 
   const loading =
     isPublicReleaseLoading ||
     isPausedLoading ||
     isConnecting ||
     isListLoading ||
-    (!active && isEaLoading) ||
-    isECLoading; // DAPPNODE
+    (!active && isEaLoading);
 
-  // DAPPNODE
-  isECLoading ? (
-    <SplashPage />
-  ) : !isInstalled ? (
-    <ECNotInstalledPage />
-  ) : !isSynced ? (
-    <ECSyncingPage />
-  ) : !hasLogs ? (
-    <ECNoLogsPage />
-  ) : isListLoading ? (
-    <ECScanningPage />
-  ) : (
-    <SplashPage />
-  );
-
-  // DAPPNODE
-  return (
-    <>
-      {loading || !isInstalled || !isSynced || !hasLogs || additional
-        ? fallback
-        : children}
-    </>
-  );
+  return <>{loading || additional ? fallback : children}</>;
 };


### PR DESCRIPTION
Implement the `GATE` logic to validate the execution client when the UI loads. This will ensure that the UI only initializes when the execution client meets the required conditions. The `Scanning Events` warning should only be shown after the user connects his wallet.