### PR TITLE
fix: One spinner for each loading warning in `/dashboard`

### DIFF
--- a/dappnode/status/styles.tsx
+++ b/dappnode/status/styles.tsx
@@ -60,6 +60,11 @@ export const WarningCard = styled(StackStyle).attrs<{ $hasWarning?: boolean }>(
     $hasWarning
       ? 'color-mix(in srgb, var(--lido-color-error) 15%, transparent)'
       : 'var(--lido-color-backgroundSecondary)'};
+
+  button {
+    border: none;
+    background: none;
+  }
 `;
 
 export const NumWarningsLabel = styled.span`

--- a/dappnode/status/warnings.tsx
+++ b/dappnode/status/warnings.tsx
@@ -76,151 +76,169 @@ export const Warnings: FC = () => {
     usedBlacklistedRelays,
   ]);
 
+  const WarningWrapper: FC<{
+    isLoading?: boolean;
+    showIf: boolean;
+    children: React.ReactNode;
+  }> = ({ isLoading = false, showIf, children }) => {
+    return isLoading ? (
+      <LoaderWrapperStyle>
+        <Loader size="small" />
+      </LoaderWrapperStyle>
+    ) : (
+      showIf && <>{children}</>
+    );
+  };
+
   return (
     <Stack direction="column" gap="sm">
-      {keysLoading || isCCLoading || isECLoading || relaysLoading ? (
-        <LoaderWrapperStyle>
-          <Loader size="medium" />
-        </LoaderWrapperStyle>
-      ) : (
-        <>
-          <WarningCard $hasWarning={numWarnings > 0}>
-            <div>
-              {numWarnings > 0 ? (
-                <h3>
-                  You have <NumWarningsLabel>{numWarnings}</NumWarningsLabel>{' '}
-                  warning/s
-                </h3>
-              ) : (
-                "You don't have any warnings"
-              )}
-            </div>
+      <WarningWrapper
+        isLoading={isECLoading || isCCLoading || keysLoading || relaysLoading}
+        showIf
+      >
+        <WarningCard $hasWarning={numWarnings > 0}>
+          <div>
+            {numWarnings > 0 ? (
+              <h3>
+                You have <NumWarningsLabel>{numWarnings}</NumWarningsLabel>{' '}
+                warning/s
+              </h3>
+            ) : (
+              "You don't have any warnings"
+            )}
+          </div>
+        </WarningCard>
+      </WarningWrapper>
+
+      <WarningWrapper
+        isLoading={isECLoading}
+        showIf={ECStatus === 'Not installed'}
+      >
+        <WarningCard $direction="column">
+          <h3>Your Execution Client is not installed!</h3>
+          <p>Please, select and sync a client from the Stakers tab.</p>
+          <Link href={stakersUiUrl}> Set Execution Client</Link>
+        </WarningCard>
+      </WarningWrapper>
+
+      <WarningWrapper
+        isLoading={isCCLoading}
+        showIf={ECStatus === 'Not installed'}
+      >
+        <WarningCard $direction="column">
+          <h3>Your Consensus Client is not installed!</h3>
+          <p>Please, select and sync a client from the Stakers tab.</p>
+          <Link href={stakersUiUrl}> Set Consensus Client</Link>
+        </WarningCard>{' '}
+      </WarningWrapper>
+
+      <WarningWrapper isLoading={keysLoading} showIf>
+        <Stack direction="column" gap="sm">
+          <WarningWrapper showIf={missingKeys.length > 0 && !errorBrain}>
+            <WarningCard $direction="column">
+              <h3>
+                {' '}
+                <NumWarningsLabel>{missingKeys.length}</NumWarningsLabel> keys
+                are not imported in Web3Signer
+              </h3>
+              {missingKeys.map((key) => (
+                <AddressRow key={key}>
+                  <Address address={key} symbols={16} />
+                  <BeaconchainPubkeyLink pubkey={key} />
+                </AddressRow>
+              ))}
+              <button onClick={() => setIsImportModalOpen(true)}>
+                <Link href={undefined}> Import keys</Link>
+              </button>
+
+              <ImportKeysWarningModal
+                isOpen={isImportModalOpen}
+                setIsOpen={setIsImportModalOpen}
+              />
+            </WarningCard>
+          </WarningWrapper>
+        </Stack>
+
+        <WarningWrapper showIf={!!errorBrain}>
+          <WarningCard $direction="column">
+            <h3>Your Brain API is not Up!</h3>
+            <p>Please, if Web3Signer is already installed, re-install it</p>
+            <Link href={stakersUiUrl}> Set Web3Signer</Link>
           </WarningCard>
+        </WarningWrapper>
 
-          {ECStatus === 'Not installed' && (
-            <WarningCard $direction="column">
-              <h3>Your Execution Client is not installed!</h3>
-              <p>Please, select and sync a client from the Stakers tab.</p>
-              <Link href={stakersUiUrl}> Set Execution Client</Link>
-            </WarningCard>
-          )}
+        <WarningWrapper showIf={validatorsExitRequests.length > 0}>
+          <WarningCard>
+            <ValidatorMapStack $direction="column">
+              <Tooltip
+                placement="top"
+                title="At least one of your validators has been requested by Lido to exit"
+              >
+                <h3>
+                  <NumWarningsLabel>
+                    {validatorsExitRequests.length}
+                  </NumWarningsLabel>{' '}
+                  Validator/s requested to exit
+                </h3>
+              </Tooltip>
+              {validatorsExitRequests.map((val) => (
+                <AddressRow key={val.pubkey}>
+                  <p>{val.index}</p>
+                  <BeaconchainPubkeyLink pubkey={val.pubkey} />
+                </AddressRow>
+              ))}
+              <Link href={brainUrl}>Exit validators</Link>
+            </ValidatorMapStack>
+          </WarningCard>
+        </WarningWrapper>
+      </WarningWrapper>
 
-          {CCStatus === 'Not installed' && (
-            <WarningCard $direction="column">
-              <h3>Your Consensus Client is not installed!</h3>
-              <p>Please, select and sync a client from the Stakers tab.</p>
-              <Link href={stakersUiUrl}> Set Consensus Client</Link>
-            </WarningCard>
-          )}
+      <WarningWrapper isLoading={relaysLoading} showIf>
+        <WarningWrapper showIf={!isMEVRunning}>
+          <WarningCard>
+            <ValidatorMapStack $direction="column">
+              <h3>MEV Boost Package is not running</h3>
+              <p>Install or restart your MEV Boost Package</p>
+              <Link href={stakersUiUrl}> Set MEV Boost</Link>
+            </ValidatorMapStack>
+          </WarningCard>
+        </WarningWrapper>
+        <WarningWrapper
+          showIf={!!(isMEVRunning && mandatoryRelays && !hasMandatoryRelay)}
+        >
+          <WarningCard>
+            <ValidatorMapStack $direction="column">
+              <h3>No mandatory Relays found</h3>
+              <p>
+                Select at least one of the mandatory MEV relays requested by
+                Lido
+              </p>
+              {mandatoryRelays?.map((relay, i) => (
+                <p key={i}>{'- ' + relay.Operator}</p>
+              ))}
+              <Link href={stakersUiUrl}>Set up Relays</Link>
+            </ValidatorMapStack>
+          </WarningCard>
+        </WarningWrapper>
 
-          {!errorBrain ? (
-            <>
-              {missingKeys.length > 0 && (
-                <Stack direction="column" gap="sm">
-                  {missingKeys.length > 0 && (
-                    <WarningCard $direction="column">
-                      <h3>
-                        {' '}
-                        <NumWarningsLabel>
-                          {missingKeys.length}
-                        </NumWarningsLabel>{' '}
-                        keys are not imported in Web3Signer
-                      </h3>
-                      {missingKeys.map((key, _) => (
-                        <AddressRow key={key}>
-                          <Address address={key} symbols={16} />
-                          <BeaconchainPubkeyLink pubkey={key} />
-                        </AddressRow>
-                      ))}
-                      <button onClick={() => setIsImportModalOpen(true)}>
-                        <Link href={undefined}> Import keys</Link>
-                      </button>
-
-                      <ImportKeysWarningModal
-                        isOpen={isImportModalOpen}
-                        setIsOpen={setIsImportModalOpen}
-                      />
-                    </WarningCard>
-                  )}
-                </Stack>
-              )}
-            </>
-          ) : (
-            <WarningCard $direction="column">
-              <h3>Your Brain API is not Up!</h3>
-              <p>Please, if Web3Signer is already installed, re-install it</p>
-              <Link href={stakersUiUrl}> Set Web3Signer</Link>
-            </WarningCard>
-          )}
-
-          {validatorsExitRequests.length > 0 && (
-            <WarningCard>
-              <ValidatorMapStack $direction="column">
-                <Tooltip
-                  placement="top"
-                  title="At least one of your validators has been requested by Lido to exit"
-                >
-                  <h3>
-                    <NumWarningsLabel>
-                      {validatorsExitRequests.length}
-                    </NumWarningsLabel>{' '}
-                    Validator/s requested to exit
-                  </h3>
-                </Tooltip>
-                {validatorsExitRequests.map((val, _) => (
-                  <AddressRow key={val.pubkey}>
-                    <p>{val.index}</p>
-                    <BeaconchainPubkeyLink pubkey={val.pubkey} />
-                  </AddressRow>
-                ))}
-                <Link href={brainUrl}>Exit validators</Link>
-              </ValidatorMapStack>
-            </WarningCard>
-          )}
-
-          {!isMEVRunning && (
-            <WarningCard>
-              <ValidatorMapStack $direction="column">
-                <h3>MEV Boost Package is not running</h3>
-                <p>Install or restart your MEV Boost Package</p>
-                <Link href={stakersUiUrl}> Set MEV Boost</Link>
-              </ValidatorMapStack>
-            </WarningCard>
-          )}
-
-          {isMEVRunning && mandatoryRelays && !hasMandatoryRelay && (
-            <WarningCard>
-              <ValidatorMapStack $direction="column">
-                <h3>No mandatory Relays found</h3>
-                <p>
-                  Select at least one of the mandatory MEV relays requested by
-                  Lido
-                </p>
-                {mandatoryRelays.map((relay, i) => (
-                  <p key={i}>{'- ' + relay.Operator}</p>
-                ))}
-                <Link href={stakersUiUrl}>Set up Relays</Link>
-              </ValidatorMapStack>
-            </WarningCard>
-          )}
-
-          {isMEVRunning && usedBlacklistedRelays.length > 0 && (
-            <WarningCard>
-              <ValidatorMapStack $direction="column">
-                <h3>Blacklisted Relays found</h3>
-                <p>The following selected relays are blacklisted by Lido:</p>
-                {usedBlacklistedRelays.map((relay, i) => (
-                  <div key={i}>
-                    - <Address symbols={30} address={relay} />
-                  </div>
-                ))}
-                <p>Please, remove the Relays above from your MEV config</p>
-                <Link href={MEVPackageConfig}>Remove blacklisted relays</Link>
-              </ValidatorMapStack>
-            </WarningCard>
-          )}
-        </>
-      )}
+        <WarningWrapper
+          showIf={!!(isMEVRunning && usedBlacklistedRelays.length > 0)}
+        >
+          <WarningCard>
+            <ValidatorMapStack $direction="column">
+              <h3>Blacklisted Relays found</h3>
+              <p>The following selected relays are blacklisted by Lido:</p>
+              {usedBlacklistedRelays.map((relay, i) => (
+                <div key={i}>
+                  - <Address symbols={30} address={relay} />
+                </div>
+              ))}
+              <p>Please, remove the Relays above from your MEV config</p>
+              <Link href={MEVPackageConfig}>Remove blacklisted relays</Link>
+            </ValidatorMapStack>
+          </WarningCard>
+        </WarningWrapper>
+      </WarningWrapper>
     </Stack>
   );
 };


### PR DESCRIPTION
Now, a separate spinner is shown for each type of warning (EC, CC, Brain, MEV). This ensures that each warning is displayed as soon as it finishes loading, without waiting for the others to load.