### PR TITLE
Dappnode `/dashboard` features + Initial calls fixed

### DIFF
--- a/dappnode/hooks/use-brain-keystore-api.ts
+++ b/dappnode/hooks/use-brain-keystore-api.ts
@@ -37,7 +37,7 @@ const useApiBrain = (interval = 60000) => {
     }, interval);
 
     return () => clearInterval(intervalId);
-  });
+  }, [fetchPubkeys, interval]);
 
   return { pubkeys, isLoading, error };
 };

--- a/dappnode/hooks/use-ec-sanity-check.ts
+++ b/dappnode/hooks/use-ec-sanity-check.ts
@@ -53,7 +53,7 @@ export const useECSanityCheck = () => {
     };
 
     void getSyncStatus();
-  });
+  }, [ECApiUrl, publicRuntimeConfig.defaultChain]);
 
   useEffect(() => {
     const getTxStatus = async () => {

--- a/dappnode/hooks/use-get-exit-requests.ts
+++ b/dappnode/hooks/use-get-exit-requests.ts
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useCallback, useState } from 'react';
 import useDappnodeUrls from './use-dappnode-urls';
 import { useActiveNodeOperator } from 'providers/node-operator-provider';
 import { fetchWithRetry } from 'dappnode/utils/fetchWithRetry';
@@ -19,7 +19,7 @@ const useGetExitRequests = () => {
   }
   type ExitRequests = Record<string, ExitRequest>;
 
-  const getExitRequests = async () => {
+  const getExitRequests = useCallback(async () => {
     try {
       setIsLoading(true);
       console.debug(`GETting validators exit requests from indexer API`);
@@ -53,7 +53,7 @@ const useGetExitRequests = () => {
       );
       setIsLoading(false);
     }
-  };
+  }, [backendUrl, nodeOperator]);
 
   return { exitRequests, getExitRequests, isLoading };
 };

--- a/dappnode/hooks/use-get-infra-status.ts
+++ b/dappnode/hooks/use-get-infra-status.ts
@@ -1,11 +1,11 @@
 import { useEffect, useState } from 'react';
 import useDappnodeUrls from './use-dappnode-urls';
-import { InfraStatus } from 'dappnode/status/types';
+import { INFRA_STATUS } from 'dappnode/status/types';
 
 export const useGetInfraStatus = () => {
   const { ECApiUrl, CCStatusApiUrl, CCVersionApiUrl } = useDappnodeUrls();
-  const [ECStatus, setECStatus] = useState<InfraStatus>();
-  const [CCStatus, setCCStatus] = useState<InfraStatus>();
+  const [ECStatus, setECStatus] = useState<INFRA_STATUS>();
+  const [CCStatus, setCCStatus] = useState<INFRA_STATUS>();
 
   const [ECName, setECName] = useState<string>();
   const [CCName, setCCName] = useState<string>();
@@ -41,11 +41,11 @@ export const useGetInfraStatus = () => {
         }
 
         const data = await syncResponse.json();
-        setCCStatus(data.data.is_syncing ? 'Syncing' : 'Synced');
+        setCCStatus(data.data.is_syncing ? 'SYNCING' : 'SYNCED');
         setIsCCLoading(false);
       } catch (e) {
         console.error(`Error getting CC data: ${e}`);
-        setCCStatus('Not installed');
+        setCCStatus('NOT_INSTALLED');
         setIsCCLoading(false);
       }
     };
@@ -90,11 +90,11 @@ export const useGetInfraStatus = () => {
         }
 
         const syncData = await syncResponse.json();
-        setECStatus(syncData.result ? 'Syncing' : 'Synced');
+        setECStatus(syncData.result ? 'SYNCING' : 'SYNCED');
         setIsECLoading(false);
       } catch (e) {
         console.error(`Error getting EC data: ${e}`);
-        setECStatus('Not installed');
+        setECStatus('NOT_INSTALLED');
         setIsECLoading(false);
       }
     };

--- a/dappnode/hooks/use-get-telegram-data.ts
+++ b/dappnode/hooks/use-get-telegram-data.ts
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useCallback, useState } from 'react';
 import useDappnodeUrls from './use-dappnode-urls';
 
 const useGetTelegramData = () => {
@@ -7,7 +7,7 @@ const useGetTelegramData = () => {
   const [botToken, setBotToken] = useState();
   const [isLoading, setIsLoading] = useState(false);
 
-  const getTelegramData = async () => {
+  const getTelegramData = useCallback(async () => {
     setIsLoading(true);
     try {
       console.debug(`GETting telegram data from events indexer API`);
@@ -35,7 +35,7 @@ const useGetTelegramData = () => {
       );
       setIsLoading(false);
     }
-  };
+  }, [backendUrl]);
 
   return { telegramId, botToken, getTelegramData, isLoading };
 };

--- a/dappnode/starter-pack/steps.tsx
+++ b/dappnode/starter-pack/steps.tsx
@@ -109,8 +109,8 @@ const Step2: FC<StepsProps> = ({ step, title, setStep }: StepsProps) => {
   const { error: brainError, isLoading: brainLoading } = useApiBrain();
   const { isMEVRunning, isLoading: relaysLoading } = useGetRelaysData();
 
-  const isECSynced: boolean = ECStatus === 'Synced';
-  const isCCSynced: boolean = CCStatus === 'Synced';
+  const isECSynced: boolean = ECStatus === 'SYNCED';
+  const isCCSynced: boolean = CCStatus === 'SYNCED';
 
   const isSignerInstalled: boolean = brainError ? false : true;
 

--- a/dappnode/status/InfraItem.tsx
+++ b/dappnode/status/InfraItem.tsx
@@ -2,14 +2,14 @@ import { FC } from 'react';
 import { TitleStyled, ItemStyled, SubtitleStyled } from './styles';
 import { Loader, Tooltip } from '@lidofinance/lido-ui';
 import { StatusChip } from 'shared/components';
-import { InfraStatus } from './types';
 import { LoaderWrapperStyle } from 'shared/navigate/splash/loader-banner/styles';
+import { INFRA_STATUS } from './types';
 
 export type InfraItemProps = {
   title: string;
   subtitle: string;
   tooltip?: string;
-  status: InfraStatus;
+  status: INFRA_STATUS;
   isLoading: boolean;
 };
 

--- a/dappnode/status/status-section.tsx
+++ b/dappnode/status/status-section.tsx
@@ -27,25 +27,25 @@ export const StatusSection: FC = () => {
     {
       title: ECName ? capitalizeFirstChar(ECName) : '-',
       subtitle: 'Execution Client',
-      status: ECStatus || 'Not installed',
+      status: ECStatus || 'NOT_INSTALLED',
       isLoading: isECLoading,
     },
     {
       title: CCName ? capitalizeFirstChar(CCName) : '-',
       subtitle: 'Consensus Client',
-      status: CCStatus || 'Not installed',
+      status: CCStatus || 'NOT_INSTALLED',
       isLoading: isCCLoading,
     },
     {
       title: 'Web3signer',
       subtitle: 'Signer',
-      status: brainKeys ? 'Installed' : 'Not installed',
+      status: brainKeys ? 'INSTALLED' : 'NOT_INSTALLED',
       isLoading: brainLoading,
     },
     {
       title: 'MEV Boost',
       subtitle: 'Relays',
-      status: isMEVRunning ? 'Installed' : 'Not installed',
+      status: isMEVRunning ? 'INSTALLED' : 'NOT_INSTALLED',
       isLoading: relaysLoading,
     },
   ];
@@ -67,8 +67,8 @@ export const StatusSection: FC = () => {
           </Row>
 
           {!!brainError ||
-          ECStatus === 'Not installed' ||
-          CCStatus === 'Not installed' ||
+          ECStatus === 'NOT_INSTALLED' ||
+          CCStatus === 'NOT_INSTALLED' ||
           !isMEVRunning ? (
             <Link href={stakersUiUrl}>Set up your node</Link>
           ) : null}

--- a/dappnode/status/types.ts
+++ b/dappnode/status/types.ts
@@ -1,9 +1,12 @@
-export type InfraStatus =
-  | 'Synced'
-  | 'Installed'
-  | 'Syncing'
-  | 'Not allowed'
-  | 'Not installed';
+export const INFRA_STATUS = {
+  SYNCED: 'SYNCED',
+  SYNCING: 'SYNCING',
+  NOT_ALLOWED: 'NOT_ALLOWED',
+  NOT_INSTALLED: 'NOT_INSTALLED',
+  INSTALLED: 'INSTALLED',
+} as const;
+
+export type INFRA_STATUS = keyof typeof INFRA_STATUS;
 
 export type AllowedRelay = {
   Description: string;

--- a/dappnode/status/warnings.tsx
+++ b/dappnode/status/warnings.tsx
@@ -42,7 +42,7 @@ export const Warnings: FC = () => {
   const [numWarnings, setNumWarnings] = useState(0);
   useEffect(() => {
     void getExitRequests();
-  });
+  }, [getExitRequests]);
 
   useEffect(() => {
     if (exitRequests) {
@@ -62,8 +62,8 @@ export const Warnings: FC = () => {
     setNumWarnings(
       validatorsExitRequests.length +
         (errorBrain ? 1 : missingKeys.length) +
-        (ECStatus === 'Not installed' ? 1 : 0) +
-        (CCStatus === 'Not installed' ? 1 : 0) +
+        (ECStatus === 'NOT_INSTALLED' ? 1 : 0) +
+        (CCStatus === 'NOT_INSTALLED' ? 1 : 0) +
         (isMEVRunning ? 0 : 1) +
         (isMEVRunning && mandatoryRelays && !hasMandatoryRelay ? 1 : 0) +
         (isMEVRunning && usedBlacklistedRelays.length > 0 ? 1 : 0),
@@ -121,7 +121,7 @@ export const Warnings: FC = () => {
 
       <WarningWrapper
         isLoading={isECLoading}
-        showIf={ECStatus === 'Not installed'}
+        showIf={ECStatus === 'NOT_INSTALLED'}
       >
         <WarningCard $direction="column">
           <h3>Your Execution Client is not installed!</h3>
@@ -132,7 +132,7 @@ export const Warnings: FC = () => {
 
       <WarningWrapper
         isLoading={isCCLoading}
-        showIf={ECStatus === 'Not installed'}
+        showIf={ECStatus === 'NOT_INSTALLED'}
       >
         <WarningCard $direction="column">
           <h3>Your Consensus Client is not installed!</h3>

--- a/features/dashboard/dashboard.tsx
+++ b/features/dashboard/dashboard.tsx
@@ -3,10 +3,16 @@ import { BondSection } from './bond';
 import { KeysSection } from './keys';
 import { RolesSection } from './roles';
 import { ExternalSection } from './external';
+import { StatusSection } from 'dappnode/status/status-section';
+import { NotificationsModal } from 'dappnode/notifications/notifications-modal';
 
 export const Dashboard: FC = () => {
   return (
     <>
+      {/* DAPPNODE */}
+      <StatusSection />
+      <NotificationsModal />
+
       <KeysSection />
       <BondSection />
       <RolesSection />

--- a/shared/components/status-chip/status-chip.tsx
+++ b/shared/components/status-chip/status-chip.tsx
@@ -2,11 +2,14 @@ import { FC } from 'react';
 import { StatusStyle, Variants } from './style';
 import { KEY_STATUS } from 'consts/key-status';
 
+// DAPPNODE
+import { INFRA_STATUS } from 'dappnode/status/types';
+
 type Props = {
-  status?: KEY_STATUS;
+  status?: KEY_STATUS | INFRA_STATUS;
 };
 
-const variants: Record<KEY_STATUS, Variants> = {
+const variants: Record<KEY_STATUS | INFRA_STATUS, Variants> = {
   [KEY_STATUS.NON_QUEUED]: 'warning',
   [KEY_STATUS.DEPOSITABLE]: 'default',
   [KEY_STATUS.ACTIVATION_PENDING]: 'default',
@@ -23,9 +26,16 @@ const variants: Record<KEY_STATUS, Variants> = {
   [KEY_STATUS.EXIT_REQUESTED]: 'warning',
   [KEY_STATUS.STUCK]: 'error',
   [KEY_STATUS.SLASHED]: 'secondary',
+
+  //DAPPNODE
+  [INFRA_STATUS.SYNCED]: 'success',
+  [INFRA_STATUS.SYNCING]: 'warning',
+  [INFRA_STATUS.NOT_ALLOWED]: 'error',
+  [INFRA_STATUS.NOT_INSTALLED]: 'error',
+  [INFRA_STATUS.INSTALLED]: 'success',
 };
 
-export const StatusTitle: Record<KEY_STATUS, string> = {
+export const StatusTitle: Record<KEY_STATUS | INFRA_STATUS, string> = {
   [KEY_STATUS.NON_QUEUED]: 'Non queued',
   [KEY_STATUS.DEPOSITABLE]: 'Depositable',
   [KEY_STATUS.ACTIVATION_PENDING]: 'Activation pending',
@@ -42,6 +52,13 @@ export const StatusTitle: Record<KEY_STATUS, string> = {
   [KEY_STATUS.EXIT_REQUESTED]: 'Exit requested',
   [KEY_STATUS.STUCK]: 'Stuck',
   [KEY_STATUS.SLASHED]: 'Slashed',
+
+  //DAPPNODE
+  [INFRA_STATUS.SYNCED]: 'Synced',
+  [INFRA_STATUS.SYNCING]: 'Syncing',
+  [INFRA_STATUS.NOT_ALLOWED]: 'Not allowed',
+  [INFRA_STATUS.NOT_INSTALLED]: 'Not installed',
+  [INFRA_STATUS.INSTALLED]: 'Installed',
 };
 
 export const StatusChip: FC<Props> = ({ status }) => (


### PR DESCRIPTION
- Adding `Status` card with `Warnings` in `/dashboard` 
- Preventing initials calls to be perma-triggered with `useCallback`