### PR TITLE
UX fixes on `starter-pack`

### DIFF
--- a/dappnode/fallbacks/ec-scanning-events.tsx
+++ b/dappnode/fallbacks/ec-scanning-events.tsx
@@ -11,10 +11,10 @@ export const ECScanningPage: FC = () => {
         <WarningWrapper>
           <h2>Execution client scanning blocks</h2>
         </WarningWrapper>
-        <p>To retrieve data, this UI needs to scan the blockchain events.</p>
+        <p>To retrieve data, this UI scans blockchain events.</p>
         <p>
-          This may take up to 10 minutes during your first login, depending on
-          your execution client.
+          The first login may take a few minutes, depending on your execution
+          client.
         </p>
         <LoaderBanner />
       </WelcomeSection>

--- a/dappnode/notifications/notifications-setup-steps.tsx
+++ b/dappnode/notifications/notifications-setup-steps.tsx
@@ -1,5 +1,6 @@
 import { FC } from 'react';
 import styled from 'styled-components';
+import { Link } from '@lidofinance/lido-ui';
 
 export const StepsList = styled.ol`
   display: flex;
@@ -29,8 +30,21 @@ export const NotificationsSteps: FC = () => {
     <>
       <StepsWrapper>
         <StepsList>
-          <li>Get Telegram user Id</li>
-          <li>Create and get a Telegram Bot token</li>
+          <li>
+            Get Telegram user Id (
+            <Link href="https://web.telegram.org/a/#52504489">
+              @userinfobot
+            </Link>{' '}
+            or{' '}
+            <Link href="https://web.telegram.org/a/#1533228735">
+              @raw_data_bot
+            </Link>
+            )
+          </li>
+          <li>
+            Create and get a Telegram Bot token (
+            <Link href="https://web.telegram.org/a/#93372553">@BotFather</Link>)
+          </li>
           <li>Start the chat with your bot</li>
         </StepsList>
       </StepsWrapper>

--- a/dappnode/starter-pack/steps.tsx
+++ b/dappnode/starter-pack/steps.tsx
@@ -20,7 +20,6 @@ import { InputTelegram } from 'dappnode/notifications/input-tg';
 import { dappnodeLidoDocsUrls } from 'dappnode/utils/dappnode-docs-urls';
 import isTelegramUserID from 'dappnode/utils/is-tg-user-id';
 import isTelegramBotToken from 'dappnode/utils/is-tg-bot-token';
-import { useChainId } from 'wagmi';
 import usePostTelegramData from 'dappnode/hooks/use-post-telegram-data';
 import useApiBrain from 'dappnode/hooks/use-brain-keystore-api';
 import { useGetInfraStatus } from 'dappnode/hooks/use-get-infra-status';
@@ -31,6 +30,10 @@ import { LoaderWrapperStyle } from 'shared/navigate/splash/loader-banner/styles'
 import { NotificationsSteps } from 'dappnode/notifications/notifications-setup-steps';
 import { CHAINS } from '@lido-sdk/constants';
 import useGetRelaysData from 'dappnode/hooks/use-get-relays-data';
+import getConfig from 'next/config';
+import { StatusTitle } from 'shared/components/status-chip/status-chip';
+
+const { publicRuntimeConfig } = getConfig();
 
 export const Steps: FC = () => {
   const StepsTitles: Record<number, string> = {
@@ -81,8 +84,8 @@ const Step1: FC<StepsProps> = ({ step, title, setStep }: StepsProps) => (
         <li>
           {' '}
           <p>
-            2 Holesky ETH (stETH / wstETH equivalent) is required for the first
-            validator{' '}
+            2 {publicRuntimeConfig.defaultChain === 17000 && 'Holesky'} ETH
+            (stETH / wstETH equivalent) is required for the first validator{' '}
           </p>
         </li>
       </ul>
@@ -121,13 +124,13 @@ const Step2: FC<StepsProps> = ({ step, title, setStep }: StepsProps) => {
 
   const { stakersUiUrl: stakersUrl } = useDappnodeUrls();
 
-  const chainId = useChainId();
   return (
     <>
       <Step stepNum={step.toString()} title={title}>
         <p>
           In order to be a Node Operator you must have a synced{' '}
-          {CHAINS[chainId]} Node and run MEV Boost.
+          {CHAINS[publicRuntimeConfig.defaultChain as CHAINS]} Node and run MEV
+          Boost.
         </p>
         <Step2InfraRow>
           <p>Execution Client</p>
@@ -139,7 +142,7 @@ const Step2: FC<StepsProps> = ({ step, title, setStep }: StepsProps) => {
               </LoaderWrapperStyle>
             ) : (
               <InfraInstalledLabel $isInstalled={isECSynced}>
-                {ECStatus}
+                {StatusTitle[ECStatus || 'NOT_INSTALLED']}
               </InfraInstalledLabel>
             )}
           </p>
@@ -155,7 +158,7 @@ const Step2: FC<StepsProps> = ({ step, title, setStep }: StepsProps) => {
               </LoaderWrapperStyle>
             ) : (
               <InfraInstalledLabel $isInstalled={isCCSynced}>
-                {CCStatus}
+                {StatusTitle[CCStatus || 'NOT_INSTALLED']}
               </InfraInstalledLabel>
             )}
           </p>
@@ -194,7 +197,9 @@ const Step2: FC<StepsProps> = ({ step, title, setStep }: StepsProps) => {
           (!isCCSynced && (
             <div>
               <ErrorWrapper>
-                You must have a synced {CHAINS[chainId]} Node and run MEV Boost.
+                You must have a synced{' '}
+                {publicRuntimeConfig.defaultChain as CHAINS} Node and run MEV
+                Boost.
               </ErrorWrapper>
             </div>
           ))}
@@ -373,10 +378,9 @@ const Step3: FC<StepsProps> = ({ step, title, setStep }: StepsProps) => {
   );
 };
 const Step4: FC<StepsProps> = ({ step, title, setStep }: StepsProps) => {
-  const chainId = useChainId() as keyof typeof CONSTANTS_BY_NETWORK;
-
   const withdrawalByAddres =
-    CONSTANTS_BY_NETWORK[chainId]?.withdrawalCredentials;
+    CONSTANTS_BY_NETWORK[publicRuntimeConfig.defaultChain as CHAINS]
+      ?.withdrawalCredentials;
 
   const handleClick = useCallback(() => {
     trackMatomoEvent(MATOMO_CLICK_EVENTS_TYPES.starterPackCreateNodeOperator);
@@ -416,7 +420,7 @@ const Step4: FC<StepsProps> = ({ step, title, setStep }: StepsProps) => {
         </Button>
 
         <NextLink href={PATH.CREATE} passHref legacyBehavior>
-          <Button onClick={handleClick}>Create Node Operator</Button>
+          <Button onClick={handleClick}>Next</Button>
         </NextLink>
       </ButtonsRow>
     </>


### PR DESCRIPTION
Includes:
- "EC Scanning Blocks" page copy updated
- Telegram links included (@botfather & @userinfobot)
- Rely on `DEFAULT_CHAIN` env instead of wallet provider to display copies
- "Create Node Operator" copy updated to "Next" ins step 4