### PR TITLE
fix: add change `RPC_URL` link to docs

### DIFF
--- a/dappnode/fallbacks/ec-scanning-events.tsx
+++ b/dappnode/fallbacks/ec-scanning-events.tsx
@@ -19,10 +19,10 @@ export const ECScanningPage: FC = () => {
           client.
         </p>
         <p>
-          Learn how to reduce the waiting time in{' '}
-          <Link href={dappnodeLidoDocsUrls.changeRPC}>
-            in our Documentation
-          </Link>
+          If you want to reduce the waiting time, use a central RPC node (e.g.,
+          Infura). <br />
+          Learn more in our{' '}
+          <Link href={dappnodeLidoDocsUrls.changeRPC}>Documentation</Link>.
         </p>
         <LoaderBanner />
       </WelcomeSection>

--- a/dappnode/fallbacks/ec-scanning-events.tsx
+++ b/dappnode/fallbacks/ec-scanning-events.tsx
@@ -3,6 +3,8 @@ import { Layout } from 'shared/layout';
 import { WelcomeSection } from './welcome-section-component';
 import { WarningWrapper } from 'dappnode/components/text-wrappers';
 import { LoaderBanner } from 'shared/navigate/splash/loader-banner';
+import { Link } from '@lidofinance/lido-ui';
+import { dappnodeLidoDocsUrls } from 'dappnode/utils/dappnode-docs-urls';
 
 export const ECScanningPage: FC = () => {
   return (
@@ -15,6 +17,12 @@ export const ECScanningPage: FC = () => {
         <p>
           The first login may take a few minutes, depending on your execution
           client.
+        </p>
+        <p>
+          Learn how to reduce the waiting time in{' '}
+          <Link href={dappnodeLidoDocsUrls.changeRPC}>
+            in our Documentation
+          </Link>
         </p>
         <LoaderBanner />
       </WelcomeSection>

--- a/dappnode/utils/dappnode-docs-urls.ts
+++ b/dappnode/utils/dappnode-docs-urls.ts
@@ -9,4 +9,5 @@ export const dappnodeLidoDocsUrls = {
     baseUrl + 'already-node-operator#3-configuring-telegram-notifications',
   notificationsNewOperator: baseUrl + 'register/#5-setup-notifications',
   pendingHashes: baseUrl + 'performance',
+  changeRPC: baseUrl + 'overview#execution-client-rpc',
 };


### PR DESCRIPTION
Adding a link in `<ECScanningPage>` that redirects to the documentation explaining how to change the `RPC_URL`.