### PR TITLE
fix: header & footer `min-width: 100%`

### DIFF
--- a/shared/layout/footer/styles.tsx
+++ b/shared/layout/footer/styles.tsx
@@ -12,7 +12,7 @@ export const FooterStyle = styled(Container)`
   flex-wrap: wrap;
   column-gap: 32px;
 
-  width: 100%;
+  min-width: 100%; // DAPPNODE
   max-width: 1424px;
   padding: 24px 32px;
 

--- a/shared/layout/header/components/navigation/styles.tsx
+++ b/shared/layout/header/components/navigation/styles.tsx
@@ -19,10 +19,10 @@ const mobileCss = css`
   bottom: 0;
   left: 0;
   right: 0;
-  padding: 8px;
+  padding: 2px; // DAPPNODE
   background-color: var(--lido-color-foreground);
   display: flex;
-  gap: 32px;
+  gap: 10px; // DAPPNODE
   justify-content: space-around;
   align-items: center;
   border-top: 1px solid var(--lido-color-border);

--- a/shared/layout/header/styles.tsx
+++ b/shared/layout/header/styles.tsx
@@ -23,6 +23,7 @@ export const HeaderContentStyle = styled.div`
 export const HeaderStyle = styled((props: ContainerProps) => (
   <Container {...props} />
 ))`
+  min-width: 100%; // DAPPNODE
   position: relative;
   padding-top: 18px;
   padding-bottom: 18px;


### PR DESCRIPTION
Ensuring that `<Header>`  and `<Footer>` take the full width of the screen to prevent "header splitting", where `<HeaderActions>` appear on a new row. 

Also includes some `<Navbar>` adjustments for better mobile responsiveness.