### PR TITLE
Retrieving processingStarted events from backend

### DIFF
--- a/dappnode/hooks/useLastRewardsFrame-api.ts
+++ b/dappnode/hooks/useLastRewardsFrame-api.ts
@@ -1,9 +1,8 @@
 import { useLidoSWR } from '@lido-sdk/react';
 import { STRATEGY_CONSTANT } from 'consts/swr-strategies';
-import { fetchWithRetry } from 'dappnode/utils/fetchWithRetry'; // DAPPNODE
-import useDappnodeUrls from 'dappnode/hooks/use-dappnode-urls'; // DAPPNODE
+import { fetchWithRetry } from 'dappnode/utils/fetchWithRetry';
+import useDappnodeUrls from 'dappnode/hooks/use-dappnode-urls';
 
-// DAPPNODE
 interface Event {
   RefSlot: number;
   Hash: number[];

--- a/dappnode/hooks/useLastRewardsFrame-api.ts
+++ b/dappnode/hooks/useLastRewardsFrame-api.ts
@@ -1,0 +1,51 @@
+import { useLidoSWR } from '@lido-sdk/react';
+import { STRATEGY_CONSTANT } from 'consts/swr-strategies';
+import { fetchWithRetry } from 'dappnode/utils/fetchWithRetry'; // DAPPNODE
+import useDappnodeUrls from 'dappnode/hooks/use-dappnode-urls'; // DAPPNODE
+
+// DAPPNODE
+interface Event {
+  RefSlot: number;
+  Hash: number[];
+  Raw: {
+    address: string;
+    topics: string[];
+    data: string;
+    blockNumber: string;
+    transactionHash: string;
+    transactionIndex: string;
+    blockHash: string;
+    logIndex: string;
+    removed: boolean;
+  };
+}
+
+export const useLastRewrdsTx = (config = STRATEGY_CONSTANT) => {
+  const { backendUrl } = useDappnodeUrls();
+
+  return useLidoSWR(
+    ['fee-oracle-report-tx'],
+    async () => {
+      const url = `${backendUrl}/api/v0/events_indexer/processing_started`;
+      const options = {
+        method: 'GET',
+        headers: { 'Content-Type': 'application/json' },
+      };
+      const response = await fetchWithRetry(url, options, 5000);
+      if (!response.ok) {
+        throw new Error('Failed to fetch processing started events');
+      }
+      const events: Event[] = await response.json();
+      const txs = events
+        .sort(
+          (a, b) =>
+            parseInt(a.Raw.blockNumber, 16) - parseInt(b.Raw.blockNumber, 16),
+        )
+        .map((event) => {
+          return event.Raw.transactionHash;
+        });
+      return txs[txs.length - 1];
+    },
+    config,
+  );
+};

--- a/features/dashboard/bond/last-rewards.tsx
+++ b/features/dashboard/bond/last-rewards.tsx
@@ -17,7 +17,6 @@ import {
   getPrevRewardsFrame,
   useLastOperatorRewards,
   useLastRewardsSlot,
-  useLastRewrdsTx,
   useNodeOperatorInfo,
 } from 'shared/hooks';
 import { formatDate, formatPercent } from 'utils';
@@ -29,6 +28,7 @@ import {
   RowHeader,
   RowTitle,
 } from './styles';
+import { useLastRewrdsTx } from 'dappnode/hooks/useLastRewardsFrame-api'; // DAPPNODE
 
 export const LastRewards: FC = () => {
   const { data: lastRewards, initialLoading: isLoading } =

--- a/shared/hooks/useLastRewardsFrame.ts
+++ b/shared/hooks/useLastRewardsFrame.ts
@@ -9,6 +9,8 @@ import { useMergeSwr } from './useMergeSwr';
 import { useMemo } from 'react';
 import { BigNumber } from 'ethers';
 import { Zero } from '@ethersproject/constants';
+import { fetchWithRetry } from 'dappnode/utils/fetchWithRetry'; // DAPPNODE
+import useDappnodeUrls from 'dappnode/hooks/use-dappnode-urls'; // DAPPNODE
 
 const SECONDS_PER_SLOT = 12;
 
@@ -143,21 +145,60 @@ export const useLastOperatorRewards = () => {
   );
 };
 
+// DAPPNODE
+interface Event {
+  RefSlot: number;
+  Hash: number[];
+  Raw: {
+    address: string;
+    topics: string[];
+    data: string;
+    blockNumber: string;
+    transactionHash: string;
+    transactionIndex: string;
+    blockHash: string;
+    logIndex: string;
+    removed: boolean;
+  };
+}
+
 export const useLastRewrdsTx = (config = STRATEGY_CONSTANT) => {
-  const feeOracle = useCSFeeOracleRPC();
-  const { deploymentBlockNumber } = getCsmConstants();
+  // DAPPNODE
+  // const feeOracle = useCSFeeOracleRPC();
+  // const { deploymentBlockNumber } = getCsmConstants();
+  const { backendUrl } = useDappnodeUrls();
 
   return useLidoSWR(
     ['fee-oracle-report-tx'],
     async () => {
-      const events = await feeOracle.queryFilter(
-        feeOracle.filters.ProcessingStarted(),
-        deploymentBlockNumber,
-      );
+      // Original code
+      // const events = await feeOracle.queryFilter(
+      //   feeOracle.filters.ProcessingStarted(),
+      //   deploymentBlockNumber,
+      // );
+      // const txs = events
+      //   .sort((a, b) => a.blockNumber - b.blockNumber)
+      //   .map((event) => {
+      //     return event.transactionHash;
+      //   });
+
+      const url = `${backendUrl}/api/v0/events_indexer/processing_started`;
+      const options = {
+        method: 'GET',
+        headers: { 'Content-Type': 'application/json' },
+      };
+      const response = await fetchWithRetry(url, options, 5000);
+      if (!response.ok) {
+        throw new Error('Failed to fetch processing started events');
+      }
+      const events: Event[] = await response.json();
       const txs = events
-        .sort((a, b) => a.blockNumber - b.blockNumber)
+        .sort(
+          (a, b) =>
+            parseInt(a.Raw.blockNumber, 16) - parseInt(b.Raw.blockNumber, 16),
+        )
         .map((event) => {
-          return event.transactionHash;
+          return event.Raw.transactionHash;
         });
       return txs[txs.length - 1];
     },

--- a/shared/hooks/useLastRewardsFrame.ts
+++ b/shared/hooks/useLastRewardsFrame.ts
@@ -9,8 +9,6 @@ import { useMergeSwr } from './useMergeSwr';
 import { useMemo } from 'react';
 import { BigNumber } from 'ethers';
 import { Zero } from '@ethersproject/constants';
-import { fetchWithRetry } from 'dappnode/utils/fetchWithRetry'; // DAPPNODE
-import useDappnodeUrls from 'dappnode/hooks/use-dappnode-urls'; // DAPPNODE
 
 const SECONDS_PER_SLOT = 12;
 
@@ -145,60 +143,22 @@ export const useLastOperatorRewards = () => {
   );
 };
 
-// DAPPNODE
-interface Event {
-  RefSlot: number;
-  Hash: number[];
-  Raw: {
-    address: string;
-    topics: string[];
-    data: string;
-    blockNumber: string;
-    transactionHash: string;
-    transactionIndex: string;
-    blockHash: string;
-    logIndex: string;
-    removed: boolean;
-  };
-}
-
+// DAPPNODE: Replaced by 'dappnode/hooks/useLastRewardsFrame-api'
 export const useLastRewrdsTx = (config = STRATEGY_CONSTANT) => {
-  // DAPPNODE
-  // const feeOracle = useCSFeeOracleRPC();
-  // const { deploymentBlockNumber } = getCsmConstants();
-  const { backendUrl } = useDappnodeUrls();
+  const feeOracle = useCSFeeOracleRPC();
+  const { deploymentBlockNumber } = getCsmConstants();
 
   return useLidoSWR(
     ['fee-oracle-report-tx'],
     async () => {
-      // Original code
-      // const events = await feeOracle.queryFilter(
-      //   feeOracle.filters.ProcessingStarted(),
-      //   deploymentBlockNumber,
-      // );
-      // const txs = events
-      //   .sort((a, b) => a.blockNumber - b.blockNumber)
-      //   .map((event) => {
-      //     return event.transactionHash;
-      //   });
-
-      const url = `${backendUrl}/api/v0/events_indexer/processing_started`;
-      const options = {
-        method: 'GET',
-        headers: { 'Content-Type': 'application/json' },
-      };
-      const response = await fetchWithRetry(url, options, 5000);
-      if (!response.ok) {
-        throw new Error('Failed to fetch processing started events');
-      }
-      const events: Event[] = await response.json();
+      const events = await feeOracle.queryFilter(
+        feeOracle.filters.ProcessingStarted(),
+        deploymentBlockNumber,
+      );
       const txs = events
-        .sort(
-          (a, b) =>
-            parseInt(a.Raw.blockNumber, 16) - parseInt(b.Raw.blockNumber, 16),
-        )
+        .sort((a, b) => a.blockNumber - b.blockNumber)
         .map((event) => {
-          return event.Raw.transactionHash;
+          return event.transactionHash;
         });
       return txs[txs.length - 1];
     },


### PR DESCRIPTION
The `useLastRewardsFrame` hook previously queried events from the `csfeeoracle` SC via local EC RPC. Now, the query is done to the backend, where these events are handled and stored in the database. This change relies on https://github.com/dappnode/lido-events/pull/124