### PR TITLE
fix: remove headers in CL keys status call

### DIFF
--- a/dappnode/status/warnings.tsx
+++ b/dappnode/status/warnings.tsx
@@ -109,7 +109,7 @@ export const Warnings: FC = () => {
           <div>
             {numWarnings > 0 ? (
               <h3>
-                You have <NumWarningsLabel>{numWarnings}</NumWarningsLabel>
+                You have <NumWarningsLabel>{numWarnings} </NumWarningsLabel>
                 warning/s
               </h3>
             ) : (

--- a/shared/hooks/use-keys-cl-status.ts
+++ b/shared/hooks/use-keys-cl-status.ts
@@ -78,6 +78,7 @@ export const useKeysCLStatus = (
         // TODO: ensure all chunks are fetched successfully
         const resp = await standardFetcher<Response>(
           `${url}?id=${keys.join(encodeURIComponent(','))}`,
+          { headers: {} }, //DAPPNODE
         );
         return resp.data.map((key) => ({
           pubkey: key.validator.pubkey,

--- a/shared/hooks/use-keys-cl-status.ts
+++ b/shared/hooks/use-keys-cl-status.ts
@@ -78,7 +78,7 @@ export const useKeysCLStatus = (
         // TODO: ensure all chunks are fetched successfully
         const resp = await standardFetcher<Response>(
           `${url}?id=${keys.join(encodeURIComponent(','))}`,
-          { headers: {} }, //DAPPNODE
+          { headers: {} }, //DAPPNODE => Needed to avoid CORS on Nimbus API. error:"...has been blocked by CORS policy: Request header field content-type is not allowed by Access-Control-Allow-Headers in preflight response"
         );
         return resp.data.map((key) => ({
           pubkey: key.validator.pubkey,


### PR DESCRIPTION
Removed headers in the Keys Status API call to the Consensus Layer to prevent CORS issues with Nimbus CC responses.